### PR TITLE
Updated install script to accomodate major docker version 

### DIFF
--- a/static/coolify/install.sh
+++ b/static/coolify/install.sh
@@ -223,8 +223,8 @@ SERVER_VERSION=$(sudo docker version -f "{{.Server.Version}}")
 SERVER_VERSION_MAJOR=$(echo "$SERVER_VERSION" | cut -d'.' -f 1)
 SERVER_VERSION_MINOR=$(echo "$SERVER_VERSION" | cut -d'.' -f 2)
 
-if [ "$SERVER_VERSION_MAJOR" -ge "$DOCKER_MAJOR" ] &&
-    [ "$SERVER_VERSION_MINOR" -ge "$DOCKER_MINOR" ]; then
+if [ "$SERVER_VERSION_MAJOR" -gt "$DOCKER_MAJOR" ] || [ [ "$SERVER_VERSION_MAJOR" -eq "$DOCKER_MAJOR" ] &&
+    [ "$SERVER_VERSION_MINOR" -ge "$DOCKER_MINOR" ] ]; then
     DOCKER_VERSION_OK="ok"
 fi
 

--- a/static/coolify/install.sh
+++ b/static/coolify/install.sh
@@ -223,8 +223,7 @@ SERVER_VERSION=$(sudo docker version -f "{{.Server.Version}}")
 SERVER_VERSION_MAJOR=$(echo "$SERVER_VERSION" | cut -d'.' -f 1)
 SERVER_VERSION_MINOR=$(echo "$SERVER_VERSION" | cut -d'.' -f 2)
 
-if [ "$SERVER_VERSION_MAJOR" -gt "$DOCKER_MAJOR" ] || [ [ "$SERVER_VERSION_MAJOR" -eq "$DOCKER_MAJOR" ] &&
-    [ "$SERVER_VERSION_MINOR" -ge "$DOCKER_MINOR" ] ]; then
+if [[ "$SERVER_VERSION_MAJOR" -gt "$DOCKER_MAJOR" || ( "$SERVER_VERSION_MAJOR" -eq "$DOCKER_MAJOR" && "$SERVER_VERSION_MINOR" -ge "$DOCKER_MINOR" ) ]]; then
     DOCKER_VERSION_OK="ok"
 fi
 


### PR DESCRIPTION
I just installed docker (which happen to be of version 23.0) and install script failed to run claiming that Docker needs to be at least 20.10. I updated the logic in docker version check to accommodate major version changes.